### PR TITLE
Change the find_minimum_nonzero function to always return non-zero minimum

### DIFF
--- a/src/basis.jl
+++ b/src/basis.jl
@@ -250,5 +250,5 @@ julia> find_minimum_nonzero([0.0, 0.0, 5.0, 1.0])
 ```
 """
 function find_minimum_nonzero(arr::Array{Float64,1})
-    return minimum(filter(x -> x != 0, arr))
+    return minimum(filter(x -> x > 0, arr))
 end


### PR DESCRIPTION
Currently, the function `find_minimum_nonzero` checks only for non-zero in the filter, and if an array with negative number is passed, the minimum returned will be negative, which is not correct according to the function name. Hence changed the filter condition to ">" which eliminates all negative and 0. 