### PR TITLE
Rename mahalabonis to mahalanobis to be consistent

### DIFF
--- a/src/.dev/test.jl
+++ b/src/.dev/test.jl
@@ -153,7 +153,7 @@ end
     y[1] = y[1] * 10.0
     x[1] = x[1] * 10.0
     datamat = DataFrame(x=x, y=y)
-    dmat = mahalabonisSquaredMatrix(datamat)
+    dmat = mahalanobisSquaredMatrix(datamat)
     d = diag(dmat)
     @test abs(d[1] - 3.2) < myeps
     @test abs(d[2] - 2.0) < myeps

--- a/src/LinRegOutliers.jl
+++ b/src/LinRegOutliers.jl
@@ -119,7 +119,7 @@ export studentizedResiduals
 export adjustedResiduals
 export jacknifedS
 export cooks
-export mahalabonisSquaredMatrix
+export mahalanobisSquaredMatrix
 
 # Ordinary least squares
 export OLS, ols, wls, residuals, predict

--- a/src/bch.jl
+++ b/src/bch.jl
@@ -87,14 +87,14 @@ function bch(Xdesign::Array{Float64,2}, y::Array{Float64,1}; alpha=0.05, maxiter
     # Algorithm 2 - Step 0.a
     coordmeds = coordinatwisemedians(X)
     A = ((X .- coordmeds')' * (X .- coordmeds')) / (n - 1)
-    dsquared = diag(mahalabonisSquaredMatrix(DataFrame(X), meanvector=coordmeds, covmatrix=A))
+    dsquared = diag(mahalanobisSquaredMatrix(DataFrame(X), meanvector=coordmeds, covmatrix=A))
     d = sqrt.(dsquared)
 
     # Algorithm 2 - Step 0.b
     bestindicesofd = sortperm(d)[1:h]
     colmeansofh = map(i -> mean(X[bestindicesofd, i]), 1:p)
     covmatofh = cov(X[bestindicesofd,:])
-    newdsquared = diag(mahalabonisSquaredMatrix(DataFrame(X), meanvector=colmeansofh, covmatrix=covmatofh))
+    newdsquared = diag(mahalanobisSquaredMatrix(DataFrame(X), meanvector=colmeansofh, covmatrix=covmatofh))
     newd = sqrt.(newdsquared)
 
     # Algorithm 2 - Steps 1, 2, 3
@@ -102,7 +102,7 @@ function bch(Xdesign::Array{Float64,2}, y::Array{Float64,1}; alpha=0.05, maxiter
     while length(basicsubsetindices) < h
         colmeanofbasicsubset = map(i -> mean(X[basicsubsetindices, i]), 1:p)
         covmatofbasicsubset = cov(X[basicsubsetindices,:]) 
-        newdsquared = diag(mahalabonisSquaredMatrix(DataFrame(X), meanvector=colmeanofbasicsubset, covmatrix=covmatofbasicsubset))
+        newdsquared = diag(mahalanobisSquaredMatrix(DataFrame(X), meanvector=colmeanofbasicsubset, covmatrix=covmatofbasicsubset))
         newd = sqrt.(newdsquared)
         basicsubsetindices = sortperm(newd)[1:(length(basicsubsetindices) + 1)]
     end
@@ -112,7 +112,7 @@ function bch(Xdesign::Array{Float64,2}, y::Array{Float64,1}; alpha=0.05, maxiter
         r = length(basicsubsetindices)
         colmeanofbasicsubset = map(i -> mean(X[basicsubsetindices, i]), 1:p)
         covmatofbasicsubset = cov(X[basicsubsetindices,:]) 
-        newdsquared = diag(mahalabonisSquaredMatrix(DataFrame(X), meanvector=colmeanofbasicsubset, covmatrix=covmatofbasicsubset))
+        newdsquared = diag(mahalanobisSquaredMatrix(DataFrame(X), meanvector=colmeanofbasicsubset, covmatrix=covmatofbasicsubset))
         newd = sqrt.(newdsquared)
         sortednewdsquared = sort(newdsquared)
         if sortednewdsquared[r + 1] >= crit 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -347,7 +347,7 @@ end
 
 
 """
-    mahalabonisSquaredMatrix(data::DataFrame; meanvector=nothing, covmatrix=nothing)
+    mahalanobisSquaredMatrix(data::DataFrame; meanvector=nothing, covmatrix=nothing)
 
 Calculate Mahalanobis distances.
 
@@ -360,13 +360,13 @@ Calculate Mahalanobis distances.
 Mahalanobis, Prasanta Chandra. "On the generalized distance in statistics." 
 National Institute of Science of India, 1936.
 """
-function mahalabonisSquaredMatrix(data::DataFrame; meanvector=nothing, covmatrix=nothing)::Union{Nothing,Array{Float64,2}}
+function mahalanobisSquaredMatrix(data::DataFrame; meanvector=nothing, covmatrix=nothing)::Union{Nothing,Array{Float64,2}}
     datamat = convert(Matrix, data)
-    return mahalabonisSquaredMatrix(datamat, meanvector=meanvector, covmatrix=covmatrix)
+    return mahalanobisSquaredMatrix(datamat, meanvector=meanvector, covmatrix=covmatrix)
 end
 
 
-function mahalabonisSquaredMatrix(datamat::Matrix; meanvector=nothing, covmatrix=nothing)::Union{Nothing,Array{Float64,2}}
+function mahalanobisSquaredMatrix(datamat::Matrix; meanvector=nothing, covmatrix=nothing)::Union{Nothing,Array{Float64,2}}
     if meanvector === nothing
         meanvector = applyColumns(mean, datamat)
     end

--- a/src/hadi1992.jl
+++ b/src/hadi1992.jl
@@ -57,14 +57,14 @@ function hadi1992(multivariateData::Array{Float64,2}; alpha=0.05)
     # Step 0
     meds = coordinatwisemedians(multivariateData)
     Sm = (1.0 / (n - 1.0)) * (multivariateData .- meds')' * (multivariateData .- meds')
-    mah0 = diag(mahalabonisSquaredMatrix(multivariateData, meanvector=meds, covmatrix=Sm))
+    mah0 = diag(mahalanobisSquaredMatrix(multivariateData, meanvector=meds, covmatrix=Sm))
     ordering_indices_mah0 = sortperm(mah0)
     best_indices_mah0 = ordering_indices_mah0[1:h]
     starting_data = multivariateData[best_indices_mah0, :]
 
     Cv = coordinatwisemedians(starting_data)
     Sv = (1.0 / (h - 1.0)) * (starting_data .- Cv')' * (starting_data .- Cv')
-    mah1 = diag(mahalabonisSquaredMatrix(multivariateData, meanvector=Cv, covmatrix=Sv))
+    mah1 = diag(mahalanobisSquaredMatrix(multivariateData, meanvector=Cv, covmatrix=Sv))
     ordering_indices_mah1 = sortperm(mah1)
 
     r = p + 1
@@ -84,11 +84,11 @@ function hadi1992(multivariateData::Array{Float64,2}; alpha=0.05)
         if det(cfactor * Sb) == 0
             @info "singular Sb case"
             newSb = hadi1992_handle_singularity(cfactor * Sb) 
-            mah1 = diag(mahalabonisSquaredMatrix(multivariateData, meanvector=Cb, covmatrix=newSb))
+            mah1 = diag(mahalanobisSquaredMatrix(multivariateData, meanvector=Cb, covmatrix=newSb))
             ordering_indices_mah1 = sortperm(mah1)
             basic_subset_indices = ordering_indices_mah1[1:r]
         else
-            mah1 = diag(mahalabonisSquaredMatrix(multivariateData, meanvector=Cb, covmatrix=(cfactor * Sb)))
+            mah1 = diag(mahalanobisSquaredMatrix(multivariateData, meanvector=Cb, covmatrix=(cfactor * Sb)))
             ordering_indices_mah1 = sortperm(mah1)
             basic_subset_indices = ordering_indices_mah1[1:r]
         end

--- a/src/mve.jl
+++ b/src/mve.jl
@@ -5,7 +5,7 @@ function enlargesubset(initialsubset, data::DataFrame, dataMatrix::Matrix, h::In
     while length(basicsubset) < h
         meanvector = applyColumns(mean, data[basicsubset,:])
         covmatrix = cov(dataMatrix[basicsubset, :])
-        md2mat = mahalabonisSquaredMatrix(data, meanvector=meanvector, covmatrix=covmatrix)
+        md2mat = mahalanobisSquaredMatrix(data, meanvector=meanvector, covmatrix=covmatrix)
         md2 = diag(md2mat)
         md2sortedindex = sortperm(md2)
         basicsubset = md2sortedindex[1:(length(basicsubset) + 1)]
@@ -37,7 +37,7 @@ function robcov(data::DataFrame; alpha=0.01, estimator=:mve)
             covmatrix = cov(dataMatrix[hsubset, :])
             if estimator == :mve
                 meanvector = applyColumns(mean, data[hsubset, :])
-                md2mat = mahalabonisSquaredMatrix(data, meanvector=meanvector, covmatrix=covmatrix)
+                md2mat = mahalanobisSquaredMatrix(data, meanvector=meanvector, covmatrix=covmatrix)
                 DJ = sqrt(sort(diag(md2mat))[h])
                 goal =  (DJ / c)^p * det(covmatrix)
             else
@@ -54,7 +54,7 @@ function robcov(data::DataFrame; alpha=0.01, estimator=:mve)
     end
     meanvector = applyColumns(mean, data[besthsubset, :])
     covariancematrix = cov(dataMatrix[besthsubset, :])
-    md2 = diag(mahalabonisSquaredMatrix(data, meanvector=meanvector, covmatrix=covariancematrix))
+    md2 = diag(mahalanobisSquaredMatrix(data, meanvector=meanvector, covmatrix=covariancematrix))
     outlierset = filter(x -> md2[x] > chisqcrit, 1:n)
     result = Dict()
     result["goal"] = mingoal

--- a/src/satman2013.jl
+++ b/src/satman2013.jl
@@ -53,7 +53,7 @@ function satman2013(X::Array{Float64,2}, y::Array{Float64,1})
     end
 
     medians = applyColumns(median, X0)
-    mhs = mahalabonisSquaredMatrix(X0, meanvector=medians, covmatrix=covmat)
+    mhs = mahalanobisSquaredMatrix(X0, meanvector=medians, covmatrix=covmat)
     if mhs isa Nothing
         md2 = zeros(Float64, n)
     else

--- a/src/satman2015.jl
+++ b/src/satman2015.jl
@@ -238,7 +238,7 @@ function satman2015(X::Array{Float64, 2}, y::Array{Float64, 1})
 
     meanvector = applyColumns(mean, X[basic_subset_indices,:])
     covmat = cov(X[basic_subset_indices,:])
-    mhs = mahalabonisSquaredMatrix(X, meanvector = meanvector, covmatrix = covmat)
+    mhs = mahalanobisSquaredMatrix(X, meanvector = meanvector, covmatrix = covmat)
     if mhs isa Nothing
         md2 = zeros(Float64, n)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,7 +154,7 @@ end
     y[1] = y[1] * 10.0
     x[1] = x[1] * 10.0
     datamat = DataFrame(x=x, y=y)
-    dmat = mahalabonisSquaredMatrix(datamat)
+    dmat = mahalanobisSquaredMatrix(datamat)
     d = diag(dmat)
     @test abs(d[1] - 3.2) < myeps
     @test abs(d[2] - 2.0) < myeps


### PR DESCRIPTION
In many places in the codebase, we had `mahalabonis` which causes problems while using search methods. Hence just renamed all the instances to be consistent with the literature.